### PR TITLE
refactor: Extend PayloadMediaProps with HTML media element attributes

### DIFF
--- a/.changeset/update-payload-types.md
+++ b/.changeset/update-payload-types.md
@@ -1,0 +1,5 @@
+---
+"@ainsleydev/sveltekit-helper": patch
+---
+
+Make `Media.alt` nullable and extend `PayloadMediaProps` with `HTMLVideoAttributes`, `HTMLImgAttributes`, and `HTMLPictureAttributes` to allow video, image, and picture props to be spread onto the rendered element.

--- a/packages/sveltekit-helper/src/components/payload/types.ts
+++ b/packages/sveltekit-helper/src/components/payload/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'svelte/elements';
+import type { HTMLAttributes, HTMLVideoAttributes, HTMLImgAttributes, HTMLPictureAttributes } from 'svelte/elements';
 
 export type MediaSizes = Record<
 	string,
@@ -11,7 +11,7 @@ export type MediaSizes = Record<
 	| undefined
 >;
 
-export type PayloadMediaProps = HTMLAttributes<HTMLElement> & {
+export type PayloadMediaProps = HTMLAttributes<HTMLElement> & HTMLVideoAttributes & HTMLImgAttributes & HTMLPictureAttributes & {
 	data: Media;
 	loading?: 'lazy' | 'eager' | undefined;
 	className?: string;
@@ -22,7 +22,7 @@ export type PayloadMediaProps = HTMLAttributes<HTMLElement> & {
 
 export type Media = {
 	id: number;
-	alt?: string;
+	alt?: string | null;
 	updatedAt: string;
 	createdAt: string;
 	deletedAt?: string | null;

--- a/packages/sveltekit-helper/src/components/payload/types.ts
+++ b/packages/sveltekit-helper/src/components/payload/types.ts
@@ -1,4 +1,9 @@
-import type { HTMLAttributes, HTMLVideoAttributes, HTMLImgAttributes, HTMLPictureAttributes } from 'svelte/elements';
+import type {
+	HTMLAttributes,
+	HTMLImgAttributes,
+	HTMLPictureAttributes,
+	HTMLVideoAttributes,
+} from 'svelte/elements';
 
 export type MediaSizes = Record<
 	string,
@@ -11,14 +16,17 @@ export type MediaSizes = Record<
 	| undefined
 >;
 
-export type PayloadMediaProps = HTMLAttributes<HTMLElement> & HTMLVideoAttributes & HTMLImgAttributes & HTMLPictureAttributes & {
-	data: Media;
-	loading?: 'lazy' | 'eager' | undefined;
-	className?: string;
-	breakpointBuffer?: number;
-	maxWidth?: number | undefined;
-	onload?: (event: Event) => void;
-};
+export type PayloadMediaProps = HTMLAttributes<HTMLElement> &
+	HTMLVideoAttributes &
+	HTMLImgAttributes &
+	HTMLPictureAttributes & {
+		data: Media;
+		loading?: 'lazy' | 'eager' | undefined;
+		className?: string;
+		breakpointBuffer?: number;
+		maxWidth?: number | undefined;
+		onload?: (event: Event) => void;
+	};
 
 export type Media = {
 	id: number;


### PR DESCRIPTION
## Summary
Enhanced the `PayloadMediaProps` type to support a broader range of HTML media element attributes by intersecting with native HTML attribute types for video, image, and picture elements. Also updated the `Media` type to allow `null` values for the `alt` property.

## Key Changes
- Added imports for `HTMLVideoAttributes`, `HTMLImgAttributes`, and `HTMLPictureAttributes` from `svelte/elements`
- Extended `PayloadMediaProps` to intersect with `HTMLVideoAttributes`, `HTMLImgAttributes`, and `HTMLPictureAttributes` in addition to the existing `HTMLAttributes<HTMLElement>`
- Updated the `Media.alt` property type from `string | undefined` to `string | null` for more explicit null handling

## Implementation Details
These changes allow the `PayloadMediaProps` type to properly support attributes specific to video, img, and picture HTML elements, providing better type safety and IDE autocomplete when using media components with these native HTML attributes. The `alt` property change aligns with how Payload CMS handles optional string fields that can be explicitly set to null.

https://claude.ai/code/session_01JsPYAtAnEtvcMbfWA1tEyz