### PR TITLE
fix: Duplicate site name in page title when no meta is set

### DIFF
--- a/.changeset/fix-duplicate-meta-title.md
+++ b/.changeset/fix-duplicate-meta-title.md
@@ -1,0 +1,5 @@
+---
+"@ainsleydev/sveltekit-helper": patch
+---
+
+Fix duplicate site name in page title when no page meta is set.

--- a/packages/sveltekit-helper/src/components/payload/PayloadSEO.svelte
+++ b/packages/sveltekit-helper/src/components/payload/PayloadSEO.svelte
@@ -121,7 +121,7 @@ const organizationSchema = $derived.by(() => {
 -->
 <svelte:head>
 	<!-- Meta -->
-	<title>{meta.title} | {siteName}</title>
+	<title>{meta.title === site ? site : `${meta.title} | ${siteName}`}</title>
 	<meta name="description" content={meta.description} />
 	<!-- Canonical -->
 	{#if meta.canonical}


### PR DESCRIPTION
## Summary
Fixed an issue where the site name was being duplicated in the page title when no custom page meta title was provided.

## Changes
- Updated the title generation logic in `PayloadSEO.svelte` to check if the meta title equals the site name before appending it
- When `meta.title` matches the `site` value (indicating no custom title was set), only the site name is displayed
- When a custom title is provided, it's formatted as `{title} | {siteName}` as intended

## Implementation Details
The fix uses a conditional expression to prevent the redundant pattern of "Site Name | Site Name" from appearing in the page title. This ensures cleaner, more semantic page titles while maintaining the desired format when custom meta titles are provided.

https://claude.ai/code/session_01P3Ms8vg5W6yoSqBfsVSWXv