### PR TITLE
fix: Ignore public_networking attribute to prevent droplet replacement

### DIFF
--- a/platform/terraform/providers/digital_ocean/droplet/main.tf
+++ b/platform/terraform/providers/digital_ocean/droplet/main.tf
@@ -37,7 +37,7 @@ resource "digitalocean_droplet" "this" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [user_data]
+    ignore_changes        = [user_data, public_networking]
   }
 
   user_data = templatefile("${path.module}/templates/server.yaml", {


### PR DESCRIPTION
The DigitalOcean Terraform provider v2.69.0 introduced public_networking as a new ForceNew attribute on digitalocean_droplet. Since existing droplets were provisioned before this attribute existed in the schema, Terraform was planning a destroy/replace on every run. Adding it to ignore_changes prevents the forced replacement without affecting the actual droplet configuration.

https://claude.ai/code/session_01PLmFfETL9zcXNotjb5fVGK