### PR TITLE
refactor: Middleware to use chi's Use instead of custom plug chain

### DIFF
--- a/internal/appdef/jsonformat/formatter.go
+++ b/internal/appdef/jsonformat/formatter.go
@@ -22,7 +22,7 @@ func RegisterType(t reflect.Type) {
 
 // scanType recursively scans a type for inline tags.
 func scanType(t reflect.Type) {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {
@@ -52,7 +52,7 @@ func scanType(t reflect.Type) {
 
 		// Recurse into struct fields.
 		fieldType := field.Type
-		for fieldType.Kind() == reflect.Ptr || fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Map {
+		for fieldType.Kind() == reflect.Pointer || fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Map {
 			fieldType = fieldType.Elem()
 		}
 		if fieldType.Kind() == reflect.Struct {

--- a/pkg/cache/mem.go
+++ b/pkg/cache/mem.go
@@ -53,7 +53,7 @@ func (c *MemCache) Get(_ context.Context, key string, value interface{}) error {
 	}
 
 	// Check if value is a pointer
-	if reflect.TypeOf(value).Kind() != reflect.Ptr {
+	if reflect.TypeOf(value).Kind() != reflect.Pointer {
 		return errors.New("value must be a pointer")
 	}
 

--- a/pkg/webkit/mux.go
+++ b/pkg/webkit/mux.go
@@ -69,6 +69,30 @@ func (k *Kit) Plug(plugs ...Plug) {
 	k.plugs = append(k.plugs, plugs...)
 }
 
+// Use registers middleware functions that run before route matching. Unlike
+// Plug, Use wraps each plug as chi router middleware so it fires on every
+// request — including OPTIONS preflights to paths that only register other
+// HTTP methods.
+//
+// For example: app.Use(middleware.CORS)
+func (k *Kit) Use(plugs ...Plug) {
+	for _, plug := range plugs {
+		k.mux.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := NewContext(w, r)
+				h := plug(func(c *Context) error {
+					r = c.Request
+					next.ServeHTTP(w, r)
+					return nil
+				})
+				if err := h(ctx); err != nil {
+					k.handleError(ctx, err)
+				}
+			})
+		})
+	}
+}
+
 // Start starts the HTTP server.
 func (k *Kit) Start(address string) error {
 	server := &http.Server{

--- a/pkg/webkit/mux.go
+++ b/pkg/webkit/mux.go
@@ -23,7 +23,6 @@ type (
 		ErrorHandler    ErrorHandler
 		NotFoundHandler Handler
 		mux             *chi.Mux
-		plugs           []Plug
 	}
 	// Handler is a function that handles HTTP requests.
 	Handler func(c *Context) error
@@ -39,7 +38,6 @@ func New() *Kit {
 		ErrorHandler:    DefaultErrorHandler,
 		NotFoundHandler: DefaultNotFoundHandler,
 		mux:             chi.NewRouter(),
-		plugs:           []Plug{},
 	}
 }
 
@@ -61,21 +59,13 @@ func (k *Kit) Add(method string, pattern string, handler Handler, plugs ...Plug)
 	})
 }
 
-// Plug adds a middleware function to the chain. These are called after
-// the funcs that are passed directly to the route-level handlers.
+// Plug registers middleware that runs before route matching, mirroring chi's
+// Use. It fires on every request — including OPTIONS preflights to paths that
+// only register other HTTP methods — making it suitable for cross-cutting
+// concerns such as CORS, logging, and request IDs.
 //
 // For example: app.Plug(middleware.Logger)
 func (k *Kit) Plug(plugs ...Plug) {
-	k.plugs = append(k.plugs, plugs...)
-}
-
-// Use registers middleware functions that run before route matching. Unlike
-// Plug, Use wraps each plug as chi router middleware so it fires on every
-// request — including OPTIONS preflights to paths that only register other
-// HTTP methods.
-//
-// For example: app.Use(middleware.CORS)
-func (k *Kit) Use(plugs ...Plug) {
 	for _, plug := range plugs {
 		k.mux.Use(func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -158,10 +148,6 @@ func (k *Kit) handle(w http.ResponseWriter, r *http.Request, handler Handler, pl
 	h := handler
 	for i := len(plugs) - 1; i >= 0; i-- {
 		h = plugs[i](h)
-	}
-
-	for i := len(k.plugs) - 1; i >= 0; i-- {
-		h = k.plugs[i](h)
 	}
 
 	if err := h(ctx); err != nil {
@@ -247,37 +233,15 @@ func (k *Kit) Mount(pattern string, handler http.Handler) {
 // Group allows you to group multiple routes together under a common path.
 // The provided function can use the `kit` to add routes, middleware, etc.
 func (k *Kit) Group(pattern string, groupFunc func(kit *Kit)) {
-	// Create a sub-router using Chi.
 	subRouter := chi.NewRouter()
 
-	// Apply middleware from parent to the subRouter.
-	for _, plug := range k.plugs {
-		subRouter.Use(func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctx := NewContext(w, r)
-				h := plug(func(c *Context) error {
-					r = c.Request
-					next.ServeHTTP(w, r)
-					return nil
-				})
-				if err := h(ctx); err != nil {
-					k.handleError(ctx, err)
-				}
-			})
-		})
-	}
-
-	// Create a new kit with the sub-router and inherit error handlers.
 	subKit := &Kit{
 		ErrorHandler:    k.ErrorHandler,
 		NotFoundHandler: k.NotFoundHandler,
 		mux:             subRouter,
-		plugs:           k.plugs, // Inherit parent plugs
 	}
 
-	// Call the provided function with the sub-kit.
 	groupFunc(subKit)
 
-	// Mount the sub router to the parent router.
 	k.mux.Mount(pattern, subRouter)
 }

--- a/pkg/webkit/mux_test.go
+++ b/pkg/webkit/mux_test.go
@@ -142,6 +142,46 @@ func TestKit_Mount(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
+func TestKit_Use(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Runs on matched route", func(t *testing.T) {
+		t.Parallel()
+		app := New()
+		app.Use(func(next Handler) Handler {
+			return func(ctx *Context) error {
+				ctx.Response.Header().Set("X-Use-Middleware", "ran")
+				return next(ctx)
+			}
+		})
+		app.Get("/thing", handler)
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/thing", nil))
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ran", rr.Header().Get("X-Use-Middleware"))
+	})
+
+	t.Run("Runs on OPTIONS preflight to GET-only route", func(t *testing.T) {
+		t.Parallel()
+		app := New()
+		app.Use(func(next Handler) Handler {
+			return func(ctx *Context) error {
+				ctx.Response.Header().Set("X-Use-Middleware", "ran")
+				if ctx.Request.Method == http.MethodOptions {
+					ctx.Response.WriteHeader(http.StatusOK)
+					return nil
+				}
+				return next(ctx)
+			}
+		})
+		app.Get("/thing", handler)
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, "/thing", nil))
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ran", rr.Header().Get("X-Use-Middleware"))
+	})
+}
+
 func TestKit_Group(t *testing.T) {
 	app := New()
 

--- a/pkg/webkit/mux_test.go
+++ b/pkg/webkit/mux_test.go
@@ -45,20 +45,45 @@ func TestAdd(t *testing.T) {
 }
 
 func TestKit_Plug(t *testing.T) {
-	app := New()
-	app.Plug(func(next Handler) Handler {
-		return func(ctx *Context) error {
-			ctx.Set("test", "test")
-			return next(ctx)
-		}
+	t.Parallel()
+
+	t.Run("Sets context value visible to handler", func(t *testing.T) {
+		t.Parallel()
+		app := New()
+		app.Plug(func(next Handler) Handler {
+			return func(ctx *Context) error {
+				ctx.Set("test", "test")
+				return next(ctx)
+			}
+		})
+		app.Get("/", func(ctx *Context) error {
+			assert.Equal(t, "test", ctx.Get("test"))
+			return ctx.String(http.StatusOK, "test")
+		})
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.Equal(t, http.StatusOK, rr.Code)
 	})
-	app.Get("/", func(ctx *Context) error {
-		assert.Equal(t, "test", ctx.Get("test"))
-		return ctx.String(http.StatusOK, "test")
+
+	t.Run("Runs on OPTIONS preflight to GET-only route", func(t *testing.T) {
+		t.Parallel()
+		app := New()
+		app.Plug(func(next Handler) Handler {
+			return func(ctx *Context) error {
+				ctx.Response.Header().Set("X-Plug-Middleware", "ran")
+				if ctx.Request.Method == http.MethodOptions {
+					ctx.Response.WriteHeader(http.StatusOK)
+					return nil
+				}
+				return next(ctx)
+			}
+		})
+		app.Get("/thing", handler)
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, "/thing", nil))
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ran", rr.Header().Get("X-Plug-Middleware"))
 	})
-	rr := httptest.NewRecorder()
-	app.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
-	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestKit_Connect(t *testing.T) {
@@ -142,45 +167,6 @@ func TestKit_Mount(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
-func TestKit_Use(t *testing.T) {
-	t.Parallel()
-
-	t.Run("Runs on matched route", func(t *testing.T) {
-		t.Parallel()
-		app := New()
-		app.Use(func(next Handler) Handler {
-			return func(ctx *Context) error {
-				ctx.Response.Header().Set("X-Use-Middleware", "ran")
-				return next(ctx)
-			}
-		})
-		app.Get("/thing", handler)
-		rr := httptest.NewRecorder()
-		app.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/thing", nil))
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "ran", rr.Header().Get("X-Use-Middleware"))
-	})
-
-	t.Run("Runs on OPTIONS preflight to GET-only route", func(t *testing.T) {
-		t.Parallel()
-		app := New()
-		app.Use(func(next Handler) Handler {
-			return func(ctx *Context) error {
-				ctx.Response.Header().Set("X-Use-Middleware", "ran")
-				if ctx.Request.Method == http.MethodOptions {
-					ctx.Response.WriteHeader(http.StatusOK)
-					return nil
-				}
-				return next(ctx)
-			}
-		})
-		app.Get("/thing", handler)
-		rr := httptest.NewRecorder()
-		app.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, "/thing", nil))
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "ran", rr.Header().Get("X-Use-Middleware"))
-	})
-}
 
 func TestKit_Group(t *testing.T) {
 	app := New()

--- a/pkg/webkit/mux_test.go
+++ b/pkg/webkit/mux_test.go
@@ -167,7 +167,6 @@ func TestKit_Mount(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
-
 func TestKit_Group(t *testing.T) {
 	app := New()
 


### PR DESCRIPTION
## Summary
This PR refactors the middleware system to leverage chi's built-in `Use` method for global middleware instead of maintaining a separate `plugs` slice. This simplifies the codebase and ensures middleware runs before route matching, making it suitable for cross-cutting concerns like CORS and logging.

## Key Changes
- **Removed `plugs` field** from the `Kit` struct and its initialization
- **Refactored `Plug` method** to directly register middleware with chi's `Use` instead of appending to a slice
- **Removed plug chain execution** from the `handle` method since middleware now runs at the chi router level
- **Simplified `Group` method** by removing the logic that manually applied parent plugs to sub-routers (no longer needed since plugs are registered globally on chi)
- **Enhanced test coverage** for `Plug` with two test cases:
  - Verifies context values set by middleware are visible to handlers
  - Verifies middleware runs on OPTIONS preflight requests to GET-only routes

## Implementation Details
The `Plug` method now wraps each middleware function to:
1. Create a new context from the request/response
2. Execute the plug with a next handler that updates the request and calls the chi handler
3. Handle any errors through the kit's error handler

This approach ensures middleware executes before route matching at the chi level, providing the expected behavior for global middleware while maintaining compatibility with the existing `Handler` and `Plug` function signatures.

https://claude.ai/code/session_01Y1KRWLLr2YC6Sisy2w2ZAJ