### PR TITLE
fix: Plug middleware to respect Response writer swaps

### DIFF
--- a/pkg/util/httputil/recorder.go
+++ b/pkg/util/httputil/recorder.go
@@ -23,7 +23,11 @@ func NewResponseRecorder(w http.ResponseWriter) *ResponseRecorder {
 }
 
 // Write writes the response body to the captured buffer and the underlying ResponseWriter.
+// Mirrors net/http behaviour: if WriteHeader has not been called, status defaults to 200.
 func (r *ResponseRecorder) Write(b []byte) (int, error) {
+	if r.Status == 0 {
+		r.Status = http.StatusOK
+	}
 	r.Body.Write(b)
 	return r.ResponseWriter.Write(b)
 }

--- a/pkg/util/httputil/recorder_test.go
+++ b/pkg/util/httputil/recorder_test.go
@@ -19,6 +19,22 @@ func TestResponseRecorder_Write(t *testing.T) {
 	assert.Equal(t, testBody, rr.Body.Bytes())
 }
 
+func TestResponseRecorder_Write_DefaultsStatusTo200(t *testing.T) {
+	// Write without a prior WriteHeader must record 200, mirroring net/http behaviour.
+	rr := NewResponseRecorder(httptest.NewRecorder())
+	_, err := rr.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rr.Status)
+}
+
+func TestResponseRecorder_Write_PreservesExplicitStatus(t *testing.T) {
+	rr := NewResponseRecorder(httptest.NewRecorder())
+	rr.WriteHeader(http.StatusCreated)
+	_, err := rr.Write([]byte("created"))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rr.Status)
+}
+
 func TestResponseRecorder_WriteHeader(t *testing.T) {
 	rr := NewResponseRecorder(httptest.NewRecorder())
 	rr.WriteHeader(http.StatusOK)

--- a/pkg/webkit/mux.go
+++ b/pkg/webkit/mux.go
@@ -71,8 +71,7 @@ func (k *Kit) Plug(plugs ...Plug) {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				ctx := NewContext(w, r)
 				h := plug(func(c *Context) error {
-					r = c.Request
-					next.ServeHTTP(w, r)
+					next.ServeHTTP(c.Response, c.Request)
 					return nil
 				})
 				if err := h(ctx); err != nil {

--- a/pkg/webkit/mux_test.go
+++ b/pkg/webkit/mux_test.go
@@ -65,6 +65,30 @@ func TestKit_Plug(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
 
+	t.Run("Response writer swap in plug is visible to downstream handler", func(t *testing.T) {
+		// Regression: Plug used to call next.ServeHTTP(w, r) with the captured outer
+		// writer, discarding any ctx.Response swap made by the plug (e.g. a recorder).
+		t.Parallel()
+		app := New()
+
+		var recorded int
+		app.Plug(func(next Handler) Handler {
+			return func(ctx *Context) error {
+				rr := httptest.NewRecorder()
+				ctx.Response = rr
+				err := next(ctx)
+				recorded = rr.Code
+				return err
+			}
+		})
+		app.Get("/", func(ctx *Context) error {
+			return ctx.String(http.StatusCreated, "hi")
+		})
+
+		app.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.Equal(t, http.StatusCreated, recorded, "plug's recorder must see the status written by the handler")
+	})
+
 	t.Run("Runs on OPTIONS preflight to GET-only route", func(t *testing.T) {
 		t.Parallel()
 		app := New()


### PR DESCRIPTION
## Summary
Fixed a bug in the `Plug` middleware system where response writer swaps made by plugs (e.g., wrapping with a recorder) were being discarded when calling the next handler. The middleware now correctly passes the potentially-modified `ctx.Response` to downstream handlers instead of always using the original outer writer.

## Key Changes
- **pkg/webkit/mux.go**: Modified `Plug` to call `next.ServeHTTP(c.Response, c.Request)` instead of `next.ServeHTTP(w, r)`, ensuring that any response writer modifications made by the plug are visible to downstream handlers
- **pkg/util/httputil/recorder.go**: Added automatic status code defaulting to 200 in `Write()` method to mirror standard `net/http` behavior when `WriteHeader` hasn't been explicitly called
- **pkg/util/httputil/recorder_test.go**: Added two test cases to verify the recorder correctly defaults status to 200 and preserves explicitly set status codes
- **pkg/webkit/mux_test.go**: Added regression test demonstrating that a plug's response writer swap (e.g., a recorder) now correctly captures the status code written by downstream handlers

## Implementation Details
The core issue was that the plug middleware was capturing the outer response writer `w` in a closure and always passing it to the next handler, ignoring any `ctx.Response` modifications. By passing `c.Response` instead, plugs can now effectively wrap or replace the response writer for the entire handler chain. The recorder status defaulting ensures compatibility with standard HTTP handler behavior.

https://claude.ai/code/session_01SYHXLF9NZsd9AvunJ6az8v